### PR TITLE
Add exclusion for abs function in clojure.core for Clojure >1.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ pom.xml.asc
 *jar
 *.class
 
-# Leiningen
+# Clojure
 /classes
 /lib
 /native
@@ -15,6 +15,7 @@ pom.xml.asc
 .lein-env
 .lein-repl-history
 .nrepl-port
+.clj-kondo
 
 # Temp Files
 *.orig
@@ -23,6 +24,9 @@ pom.xml.asc
 .*.swo
 *.tmp
 *.bak
+.cpcache
+.idea
+*.iml
 
 # OS X
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -8,11 +8,14 @@ The guide also explains the limitations of this type of datum transformation, in
 Available calculations:
 * convert latitude and longitude to grid eastings and northings for the Ordnance Survey National Grid Transverse Mercator map projection - and vice versa
 
+This is a fork of https://github.com/dilico/geocoordinates and will be removed if the original
+repository is updated. 
+
 ## Installation
 
-Via Clojars: http://clojars.org/geocoordinates
+Via Clojars: [https://clojars.org/com.eldrix/geocoordinates](https://clojars.org/com.eldrix/geocoordinates)
 
-[![Clojars Project](http://clojars.org/geocoordinates/latest-version.svg)](http://clojars.org/geocoordinates)
+[![Clojars Project](https://img.shields.io/clojars/v/com.eldrix/geocoordinates.svg)](https://clojars.org/com.eldrix/geocoordinates)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,30 @@ To convert from latitude and longitude to easting and northing for the Ordnance 
 (geo/latitude-longitude->easting-northing {:latitude 52.65757 :longitude 1.7179215} :national-grid)
 ```
 
+## Development
+
+To run unit tests:
+```shell
+clj -M:test
+```
+
+To create a jar file:
+
+```shell
+clj -T:build jar
+```
+
+To install into local maven repository:
+```shell
+clj -T:build install
+```
+
+To upload to clojars:
+```shell
+clj -T:build deploy
+```
+To deploy, environment variables CLOJARS_USERNAME and CLOJARS_PASSWORD must be set.
+
 ## License
 
 Copyright © 2015 dilico

--- a/build.clj
+++ b/build.clj
@@ -2,7 +2,7 @@
   (:require [clojure.tools.build.api :as b]
             [deps-deploy.deps-deploy :as dd]))
 
-(def lib 'com.github.dilico/geocoordinates)
+(def lib 'com.eldrix/geocoordinates)
 (def version (format "0.1.%s" (b/git-count-revs nil)))
 (def class-dir "target/classes")
 (def jar-basis (b/create-basis {:project "deps.edn"}))

--- a/build.clj
+++ b/build.clj
@@ -20,10 +20,10 @@
                     :version   version
                     :basis     jar-basis
                     :src-dirs  ["src"]
-                    :scm       {:url                 "https://github.com/dilico/geocoordinates"
+                    :scm       {:url                 "https://github.com/wardle/geocoordinates"
                                 :tag                 (str "v" version)
-                                :connection          "scm:git:git://github.com/dilico/geocoordinates.git"
-                                :developerConnection "scm:git:ssh://git@github.com/dilico/geocoordinates.git"}})
+                                :connection          "scm:git:git://github.com/wardle/geocoordinates.git"
+                                :developerConnection "scm:git:ssh://git@github.com/wardle/geocoordinates.git"}})
       (b/copy-dir {:src-dirs   ["src" "resources"]
                    :target-dir class-dir})
       (b/jar {:class-dir class-dir

--- a/build.clj
+++ b/build.clj
@@ -1,0 +1,54 @@
+(ns build
+  (:require [clojure.tools.build.api :as b]
+            [deps-deploy.deps-deploy :as dd]))
+
+(def lib 'com.github.dilico/geocoordinates)
+(def version (format "0.1.%s" (b/git-count-revs nil)))
+(def class-dir "target/classes")
+(def jar-basis (b/create-basis {:project "deps.edn"}))
+(def jar-file (format "target/%s-%s.jar" (name lib) version))
+
+
+(defn clean [_]
+      (b/delete {:path "target"}))
+
+(defn jar [_]
+      (clean nil)
+      (println "Building" jar-file)
+      (b/write-pom {:class-dir class-dir
+                    :lib       lib
+                    :version   version
+                    :basis     jar-basis
+                    :src-dirs  ["src"]
+                    :scm       {:url                 "https://github.com/dilico/geocoordinates"
+                                :tag                 (str "v" version)
+                                :connection          "scm:git:git://github.com/dilico/geocoordinates.git"
+                                :developerConnection "scm:git:ssh://git@github.com/dilico/geocoordinates.git"}})
+      (b/copy-dir {:src-dirs   ["src" "resources"]
+                   :target-dir class-dir})
+      (b/jar {:class-dir class-dir
+              :jar-file  jar-file}))
+
+(defn install
+      "Installs pom and library jar in local maven repository"
+      [_]
+      (jar nil)
+      (println "Installing" jar-file)
+      (b/install {:basis     jar-basis
+                  :lib       lib
+                  :class-dir class-dir
+                  :version   version
+                  :jar-file  jar-file}))
+
+
+(defn deploy
+      "Deploy library to clojars.
+      Environment variables CLOJARS_USERNAME and CLOJARS_PASSWORD must be set."
+      [_]
+      (println "Deploying" jar-file)
+      (clean nil)
+      (jar nil)
+      (dd/deploy {:installer :remote
+                  :artifact  jar-file
+                  :pom-file  (b/pom-path {:lib       lib
+                                          :class-dir class-dir})}))

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,12 @@
+{:paths   ["src"]
+ :deps    {org.clojure/clojure {:mvn/version "1.9.0"}}
+ :aliases {
+           :build
+           {:deps       {io.github.clojure/tools.build {:git/tag "v0.8.3" :git/sha "0d20256"}
+                         slipset/deps-deploy           {:mvn/version "RELEASE"}}
+            :ns-default build}
+
+           :test {:extra-paths ["test"]
+                  :extra-deps  {org.clojure/test.check               {:mvn/version "1.1.1"}
+                                io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                  :main-opts   ["-m" "cognitect.test-runner"]}}}

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,0 @@
-(defproject geocoordinates "0.1.0"
-  :description "A Clojure library for carrying out common calculations with geographical coordinates."
-  :url "http://github.com/dilico/geocoordinates"
-  :author "dilico"
-  :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0"]]
-  :deploy-repositories [["releases" :clojars]])

--- a/src/geocoordinates/core.clj
+++ b/src/geocoordinates/core.clj
@@ -10,14 +10,14 @@
   "National Grid Transverse Mercator projection constants
   (latitude and longitude in decimal degrees, easting and northing in metres)."
   {:scale-factor-on-central-meridian-f0 0.9996012717
-   :true-origin-latitude-φ0 49
-   :true-origin-longitude-λ0 -2
-   :true-origin-easting-e0 400000
-   :true-origin-northing-n0 -100000})
+   :true-origin-latitude-φ0             49
+   :true-origin-longitude-λ0            -2
+   :true-origin-easting-e0              400000
+   :true-origin-northing-n0             -100000})
 
 (def ^:private national-grid-constants
   "Ellipsoid and projection constants for the National Grid projection."
-  {:ellipsoid-constants airy-1830-ellipsoid-constants
+  {:ellipsoid-constants                      airy-1830-ellipsoid-constants
    :transverse-mercator-projection-constants national-grid-transverse-mercator-projection-constants})
 
 (def ^:private projections-constants
@@ -27,11 +27,11 @@
 (defn- meridional-arc
   "Compute the meridional arc."
   [bf0 n true-origin-latitude-φ0 initial-or-final-latitude-φ]
-  (let [t1 (* (+ 1 n (* (/ 5 4) (math/exp n 2)) (* (/ 5 4) (math/exp n 3))) 
+  (let [t1 (* (+ 1 n (* (/ 5 4) (math/exp n 2)) (* (/ 5 4) (math/exp n 3)))
               (- initial-or-final-latitude-φ true-origin-latitude-φ0))
-        t2 (*  (+ (* 3 n) (* 3 (math/exp n 2)) (* (/ 21 8) (math/exp n 3)))
-               (math/sin (- initial-or-final-latitude-φ true-origin-latitude-φ0))
-               (math/cos (+ initial-or-final-latitude-φ true-origin-latitude-φ0)))
+        t2 (* (+ (* 3 n) (* 3 (math/exp n 2)) (* (/ 21 8) (math/exp n 3)))
+              (math/sin (- initial-or-final-latitude-φ true-origin-latitude-φ0))
+              (math/cos (+ initial-or-final-latitude-φ true-origin-latitude-φ0)))
         t3 (* (+ (* (/ 15 8) (math/exp n 2)) (* (/ 15 8) (math/exp n 3)))
               (math/sin (* 2 (- initial-or-final-latitude-φ true-origin-latitude-φ0)))
               (math/cos (* 2 (+ initial-or-final-latitude-φ true-origin-latitude-φ0))))
@@ -46,11 +46,11 @@
   [northing true-origin-northing-n0 af0 true-origin-latitude-φ0 n bf0]
   (let [calculate-arc (fn [φ1-val]
                         (meridional-arc bf0 n true-origin-latitude-φ0 φ1-val))
-        calculate-φ (fn [arc-val φ1-val] 
+        calculate-φ (fn [arc-val φ1-val]
                       (+ (/ (- northing true-origin-northing-n0 arc-val) af0) φ1-val))
         initial-φ (+ (/ (- northing true-origin-northing-n0) af0) true-origin-latitude-φ0)
         initial-arc (calculate-arc initial-φ)]
-    
+
     (loop [φ initial-φ
            arc initial-arc]
       (if (> (math/abs (- northing true-origin-northing-n0 arc)) (math/exp 10 -5))
@@ -70,19 +70,19 @@
         n (/ (- af0 bf0) (+ af0 bf0))
         et (- easting (:true-origin-easting-e0 (:transverse-mercator-projection-constants constants)))
         φ (initial-latitude northing
-                            (:true-origin-northing-n0 (:transverse-mercator-projection-constants constants)) 
+                            (:true-origin-northing-n0 (:transverse-mercator-projection-constants constants))
                             af0
                             (math/decimal-degrees->radians (:true-origin-latitude-φ0
-                                                            (:transverse-mercator-projection-constants
-                                                             constants)))
-                             n
-                             bf0)
-        ν (/ af0 
+                                                             (:transverse-mercator-projection-constants
+                                                               constants)))
+                            n
+                            bf0)
+        ν (/ af0
              (math/sqrt (- 1 (* e2 (math/exp (math/sin φ) 2)))))
         ρ (/ (* ν (- 1 e2))
              (- 1 (* e2 (math/exp (math/sin φ) 2))))
         η2 (- (/ ν ρ) 1)]
-    
+
     {:af0 af0 :bf0 bf0 :e2 e2 :n n :et et :φ φ :ν ν :ρ ρ :η2 η2}))
 
 (defn- easting-northing->latitude
@@ -95,7 +95,7 @@
                 (+ 5 (* 3 (math/exp (math/tan φ) 2)) (- η2 (* 9 η2 (math/exp (math/tan φ) 2)))))
         IX (* (/ (math/tan φ) (* 720 ρ (math/exp ν 5)))
               (+ 61 (* 90 (math/exp (math/tan φ) 2)) (* 45 (math/exp (math/tan φ) 4))))]
-    
+
     (* (/ 180 math/pi)
        (+ (- φ (* (math/exp et 2) VII)) (- (* (math/exp et 4) VIII) (* (math/exp et 6) IX))))))
 
@@ -105,15 +105,15 @@
   (let [{af0 :af0 bf0 :bf0 e2 :e2 n :n et :et φ :φ ν :ν ρ :ρ η2 :η2}
         (compute-easting-northing-conversion-parameters easting northing constants)
         λ0 (math/decimal-degrees->radians (:true-origin-longitude-λ0
-                                           (:transverse-mercator-projection-constants
-                                            constants)))
+                                            (:transverse-mercator-projection-constants
+                                              constants)))
         X (/ (math/exp (math/cos φ) -1) ν)
         XI (* (/ (math/exp (math/cos φ) -1) (* 6 (math/exp ν 3)))
               (+ (/ ν ρ) (* 2 (math/exp (math/tan φ) 2))))
         XII (* (/ (math/exp (math/cos φ) -1) (* 120 (math/exp ν 5)))
                (+ 5 (* 28 (math/exp (math/tan φ) 2)) (* 24 (math/exp (math/tan φ) 4))))
         XIIA (* (/ (math/exp (math/cos φ) -1) (* 5040 (math/exp ν 7)))
-                (+ 61 
+                (+ 61
                    (* 662 (math/exp (math/tan φ) 2))
                    (* 1320 (math/exp (math/tan φ) 4))
                    (* 720 (math/exp (math/tan φ) 6))))]
@@ -123,7 +123,7 @@
 (defn easting-northing->latitude-longitude
   "Convert easting and northing to latitude and longitude (in decimal degrees)."
   [{easting :easting northing :northing} projection]
-  {:latitude (easting-northing->latitude easting northing (projection projections-constants))
+  {:latitude  (easting-northing->latitude easting northing (projection projections-constants))
    :longitude (easting-northing->longitude easting northing (projection projections-constants))})
 
 (defn- compute-latitude-longitude-conversion-parameters
@@ -136,16 +136,16 @@
         e2 (/ (- (math/exp af0 2) (math/exp bf0 2)) (math/exp af0 2))
         n (/ (- af0 bf0) (+ af0 bf0))
         φ (math/decimal-degrees->radians latitude)
-        ν (/ af0 
+        ν (/ af0
              (math/sqrt (- 1 (* e2 (math/exp (math/sin φ) 2)))))
         ρ (/ (* ν (- 1 e2))
              (- 1 (* e2 (math/exp (math/sin φ) 2))))
         η2 (- (/ ν ρ) 1)
         p (- (math/decimal-degrees->radians longitude)
              (math/decimal-degrees->radians (:true-origin-longitude-λ0
-                                             (:transverse-mercator-projection-constants
-                                              constants))))]
-    
+                                              (:transverse-mercator-projection-constants
+                                                constants))))]
+
     {:af0 af0 :bf0 bf0 :e2 e2 :n n :φ φ :ν ν :ρ ρ :η2 η2 :p p}))
 
 (defn- latitude-longitude->easting
@@ -157,7 +157,7 @@
         V (* (/ ν 6)
              (math/exp (math/cos φ) 3)
              (- (/ ν ρ) (math/exp (math/tan φ) 2)))
-        VI (* (/ ν 120) 
+        VI (* (/ ν 120)
               (math/exp (math/cos φ) 5)
               (- (+ (- 5 (* 18 (math/exp (math/tan φ) 2)))
                     (math/exp (math/tan φ) 4)
@@ -174,21 +174,21 @@
   (let [{af0 :af0 bf0 :bf0 e2 :e2 n :n φ :φ ν :ν ρ :ρ η2 :η2 p :p}
         (compute-latitude-longitude-conversion-parameters latitude longitude constants)
         φ0 (math/decimal-degrees->radians (:true-origin-latitude-φ0
-                                           (:transverse-mercator-projection-constants
-                                            constants)))
+                                            (:transverse-mercator-projection-constants
+                                              constants)))
         arc (meridional-arc bf0 n φ0 φ)
         I (+ arc (:true-origin-northing-n0
-                  (:transverse-mercator-projection-constants
-                   constants)))
+                   (:transverse-mercator-projection-constants
+                     constants)))
         II (* (/ ν 2) (math/sin φ) (math/cos φ))
-        III (* (/ ν 24) (math/sin φ) (math/exp (math/cos φ) 3) 
+        III (* (/ ν 24) (math/sin φ) (math/exp (math/cos φ) 3)
                (+ (- 5 (math/exp (math/tan φ) 2)) (* 9 η2)))
-        IIIA (* (/ ν 720) (math/sin φ) (math/exp (math/cos φ) 5) 
+        IIIA (* (/ ν 720) (math/sin φ) (math/exp (math/cos φ) 5)
                 (+ (- 61 (* 58 (math/exp (math/tan φ) 2))) (math/exp (math/tan φ) 4)))]
     (+ I (* (math/exp p 2) II) (* (math/exp p 4) III) (* (math/exp p 6) IIIA))))
 
 (defn latitude-longitude->easting-northing
   "Convert latitude and longitude (in decimal degrees) to easting and northing."
   [{latitude :latitude longitude :longitude} projection]
-  {:easting (latitude-longitude->easting latitude longitude (projection projections-constants))
+  {:easting  (latitude-longitude->easting latitude longitude (projection projections-constants))
    :northing (latitude-longitude->northing latitude longitude (projection projections-constants))})

--- a/src/geocoordinates/math.clj
+++ b/src/geocoordinates/math.clj
@@ -1,4 +1,5 @@
-(ns geocoordinates.math)
+(ns geocoordinates.math
+  (:refer-clojure :exclude [abs]))
 
 (def pi
   "Number pi."


### PR DESCRIPTION
In Clojure 1.11 and above, clojure.core contains a new 'abs' function. To avoid warnings, exclude this function.