### PR TITLE
Modernize tooling and avoid warnings for Clojure >=1.11.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ pom.xml.asc
 .*.swo
 *.tmp
 *.bak
+*.iml
+.cpcache
+.idea
 
 # OS X
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -43,6 +43,40 @@ To convert from latitude and longitude to easting and northing for the Ordnance 
 (geo/latitude-longitude->easting-northing {:latitude 52.65757 :longitude 1.7179215} :national-grid)
 ```
 
+# Development
+
+To run unit tests:
+```shell
+clj -M:test
+```
+
+To see outdated dependencies
+```shell
+clj -M:outdated
+```
+
+To interactively update outdated dependencies
+```shell
+clj -M:upgrade
+```
+
+To create a jar file:
+
+```shell
+clj -T:build jar
+```
+
+To install into local maven repository:
+```shell
+clj -T:build install
+```
+
+To upload to clojars:
+```shell
+clj -T:build deploy
+```
+To deploy, environment variables CLOJARS_USERNAME and CLOJARS_PASSWORD must be set.
+
 ## License
 
 Copyright © 2015 dilico

--- a/build.clj
+++ b/build.clj
@@ -1,0 +1,54 @@
+(ns build
+  (:require [clojure.tools.build.api :as b]
+            [deps-deploy.deps-deploy :as dd]))
+
+(def lib 'io.github.dilico/geocoordinates)
+(def version (format "0.1.%s" (b/git-count-revs nil)))
+(def class-dir "target/classes")
+(def jar-basis (b/create-basis {:project "deps.edn"}))
+(def jar-file (format "target/%s-%s.jar" (name lib) version))
+
+
+(defn clean [_]
+      (b/delete {:path "target"}))
+
+(defn jar [_]
+      (clean nil)
+      (println "Building" jar-file)
+      (b/write-pom {:class-dir class-dir
+                    :lib       lib
+                    :version   version
+                    :basis     jar-basis
+                    :src-dirs  ["src"]
+                    :scm       {:url                 "https://github.com/dilico/geocoordinates"
+                                :tag                 (str "v" version)
+                                :connection          "scm:git:git://github.com/dilico/geocoordinates.git"
+                                :developerConnection "scm:git:ssh://git@github.com/dilico/geocoordinates.git"}})
+      (b/copy-dir {:src-dirs   ["src" "resources"]
+                   :target-dir class-dir})
+      (b/jar {:class-dir class-dir
+              :jar-file  jar-file}))
+
+(defn install
+      "Installs pom and library jar in local maven repository"
+      [_]
+      (jar nil)
+      (println "Installing" jar-file)
+      (b/install {:basis     jar-basis
+                  :lib       lib
+                  :class-dir class-dir
+                  :version   version
+                  :jar-file  jar-file}))
+
+
+(defn deploy
+      "Deploy library to clojars.
+      Environment variables CLOJARS_USERNAME and CLOJARS_PASSWORD must be set."
+      [_]
+      (println "Deploying" jar-file)
+      (clean nil)
+      (jar nil)
+      (dd/deploy {:installer :remote
+                  :artifact  jar-file
+                  :pom-file  (b/pom-path {:lib       lib
+                                          :class-dir class-dir})}))

--- a/build.clj
+++ b/build.clj
@@ -3,7 +3,7 @@
             [deps-deploy.deps-deploy :as dd]))
 
 (def lib 'io.github.dilico/geocoordinates)
-(def version (format "0.1.%s" (b/git-count-revs nil)))
+(def version (format "0.2.%s" (b/git-count-revs nil)))
 (def class-dir "target/classes")
 (def jar-basis (b/create-basis {:project "deps.edn"}))
 (def jar-file (format "target/%s-%s.jar" (name lib) version))

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,20 @@
+{:paths   ["src"]
+ :deps    {org.clojure/clojure {:mvn/version "1.11.1"}}
+ :aliases {
+           :build
+           {:deps       {io.github.clojure/tools.build {:git/tag "v0.9.4" :git/sha "76b78fe"}
+                         slipset/deps-deploy           {:mvn/version "RELEASE"}}
+            :ns-default build}
+
+           :outdated
+           {:extra-deps {com.github.liquidz/antq {:mvn/version "RELEASE"}}
+            :main-opts  ["-m" "antq.core"]}
+
+           :upgrade
+           {:extra-deps {com.github.liquidz/antq {:mvn/version "RELEASE"}}
+            :main-opts  ["-m" "antq.core" "--upgrade"]}
+
+           :test {:extra-paths ["test"]
+                  :extra-deps  {org.clojure/test.check               {:mvn/version "1.1.1"}
+                                io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                  :main-opts   ["-m" "cognitect.test-runner"]}}}

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,0 @@
-(defproject geocoordinates "0.1.0"
-  :description "A Clojure library for carrying out common calculations with geographical coordinates."
-  :url "http://github.com/dilico/geocoordinates"
-  :author "dilico"
-  :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0"]]
-  :deploy-repositories [["releases" :clojars]])

--- a/src/geocoordinates/math.clj
+++ b/src/geocoordinates/math.clj
@@ -1,4 +1,5 @@
-(ns geocoordinates.math)
+(ns geocoordinates.math
+  (:refer-clojure :exclude [abs]))
 
 (def pi
   "Number pi."


### PR DESCRIPTION
I am sorry for delay. As requested, I've combined the two PRs into a single PR to modernize this library.

- Change from leiningen to deps.edn and tools.build
- Update library name and version to use a more modern idiomatic scheme io.github.dilico/geocoordinates
- Exclude new function (abs) in clojure.core >=1.11.x to avoid warnings when library is used from modern Clojure.

